### PR TITLE
feat: add get_issue_comments

### DIFF
--- a/src/youtrack_rocket_mcp/api/resources/issues.py
+++ b/src/youtrack_rocket_mcp/api/resources/issues.py
@@ -374,6 +374,32 @@ class IssuesClient:
 
         return issues
 
+    async def get_issue_comments(self, issue_id: str) -> list[JSONDict]:
+        """
+        Get comments for an issue.
+
+        Args:
+            issue_id: The issue ID or readable ID (e.g., PROJECT-123)
+
+        Returns:
+            List of comments with id, created timestamp, text, and author information
+        """
+        # Request comments with detailed author information
+        fields = 'id,created,text,author(id,login,name)'
+        response = await self.client.get(f'issues/{issue_id}/comments?fields={fields}')
+
+        # The response should be a list of comments
+        if isinstance(response, list):
+            return response
+        elif isinstance(response, dict) and 'comments' in response:
+            return response['comments']
+        else:
+            # Fallback: try to get comments as part of issue data
+            issue_response = await self.client.get(f'issues/{issue_id}?fields=comments({fields})')
+            if isinstance(issue_response, dict) and 'comments' in issue_response:
+                return issue_response['comments']
+            return []
+
     async def add_comment(self, issue_id: str, text: str) -> JSONDict:
         """
         Add a comment to an issue.

--- a/src/youtrack_rocket_mcp/tools/issues.py
+++ b/src/youtrack_rocket_mcp/tools/issues.py
@@ -371,6 +371,29 @@ class IssueTools:
             logger.exception(f'Error creating issue in project {project}')
             return json.dumps({'error': str(e), 'status': 'error'})
 
+    async def get_issue_comments(self, issue_id: str) -> str:
+        """
+        Get all comments for an issue.
+
+        FORMAT: get_issue_comments(issue_id="DEMO-123")
+
+        Args:
+            issue_id: The issue ID or readable ID (e.g., PROJECT-123)
+
+        Returns:
+            JSON string with the list of comments
+        """
+        try:
+            comments = await self.issues_api.get_issue_comments(issue_id)
+
+            # Format the response with metadata
+            result = {'issue_id': issue_id, 'comments_count': len(comments), 'comments': comments}
+
+            return json.dumps(result, indent=2)
+        except Exception as e:
+            logger.exception(f'Error getting comments for issue {issue_id}')
+            return json.dumps({'error': str(e), 'issue_id': issue_id})
+
     async def add_comment(self, issue_id: str, text: str) -> str:
         """
         Add a comment to an issue.
@@ -542,6 +565,13 @@ def register_issue_tools(mcp: FastMCP) -> None:
             parsed_custom_fields = custom_fields
 
         return await issue_tools.create_issue(project, summary, description, parsed_custom_fields)
+
+    @mcp.tool()
+    async def get_issue_comments(
+        issue_id: Annotated[str, Field(description='Issue ID (e.g., ITSFT-123 or 2-12345)')],
+    ) -> str:
+        """Retrieve all comments for an issue. Use to read discussion history, updates, and clarifications. Returns JSON with comment details."""
+        return await issue_tools.get_issue_comments(issue_id)
 
     @mcp.tool()
     async def add_comment(


### PR DESCRIPTION
Hi, 

Thanks for the repo very useful!

It seemed that even with get issue raw and issue details I could not read the comments.

To collect them it requires passing extra issue fields `comments` in the post request

https://www.jetbrains.com/help/youtrack/devportal/api-entity-Issue.html#-oazh6f_4

This is generated by Claude and I have been using it since and it seems fine. 

But feel free to close if not useful